### PR TITLE
Snap: Do not crash when cur-focus-scale is null

### DIFF
--- a/src/com/android/camera/PhotoModule.java
+++ b/src/com/android/camera/PhotoModule.java
@@ -3764,7 +3764,14 @@ public class PhotoModule
             final int maxFocusPos = mParameters.getInt(CameraSettings.KEY_MAX_FOCUS_SCALE);
             //update mparameters to fetch latest focus position
             mParameters = mCameraDevice.getParameters();
-            final int CurFocusPos = mParameters.getInt(CameraSettings.KEY_MANUAL_FOCUS_SCALE);
+            int CurFocusPos = minFocusPos;
+
+            try {
+                 CurFocusPos = mParameters.getInt(CameraSettings.KEY_MANUAL_FOCUS_SCALE);
+            } catch (NumberFormatException e) {
+                 // Do nothing
+            }
+
             focusbar.setProgress(CurFocusPos);
             focusPositionText.setText("Current focus position is " + CurFocusPos);
 
@@ -3816,7 +3823,8 @@ public class PhotoModule
             //update mparameters to fetch latest focus position
             mParameters = mCameraDevice.getParameters();
             final String CurFocusPos = mParameters.get(CameraSettings.KEY_MANUAL_FOCUS_DIOPTER);
-            focusPositionText.setText("Current focus position is " + CurFocusPos);
+            focusPositionText.setText("Current focus position is " +
+                    (CurFocusPos != null ? CurFocusPos : minFocusStr));
             linear.addView(input);
             linear.addView(focusPositionText);
             alert.setView(linear);


### PR DESCRIPTION
* Some cameras simply don't set this parameter.
* Also set cur-focus-diopter to 0 if it's null.

Change-Id: Ib1049012de9a58279560c14ed77f83f52c07fe30